### PR TITLE
Fix color variable

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,7 +24,7 @@
     --primary: 210 11% 4%;
     --primary-foreground: 210 50% 98%;
     --secondary: 210 22% 96%;
-    --secondary-foreground: 210 22 96;
+    --secondary-foreground: 210 22% 96%;
     --muted: 0 0% 94%;
     --muted-foreground: 0 0% 38%;
     --accent: 0 0% 96.1%;


### PR DESCRIPTION
## Summary
- correct hsl percentages for secondary foreground color

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_683f86f6c0a4832b810c38c25d6546cb