### PR TITLE
Normalize UI text casing and simplify ThemeToggle to use `resolvedTheme`

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
       </header>
 
       <section className="mt-16">
-        <h2 className="text-sm font-medium text-muted tracking-widest">
+        <h2 className="text-base font-medium text-muted tracking-normal">
           experience
         </h2>
         <div className="mt-6 space-y-6">
@@ -58,7 +58,7 @@ export default function Home() {
       </section>
 
       <section className="mt-16">
-        <h2 className="text-sm font-medium text-muted tracking-widest">
+        <h2 className="text-base font-medium text-muted tracking-normal">
           projects
         </h2>
         <div className="mt-6 space-y-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,10 +6,14 @@ const WEBRING_URL = "https://mac-csse-webring.vercel.app/";
 const MY_SITE = "eddiezhuang.com";
 
 const socialLinks = [
-  { href: "mailto:zhuang.eddie@gmail.com", icon: MailIcon, label: "Email" },
-  { href: "https://github.com/edzhuang", icon: GitHubIcon, label: "GitHub" },
-  { href: "https://www.linkedin.com/in/eddie-zhuang", icon: LinkedInIcon, label: "LinkedIn" },
-  { href: "https://x.com/edzhuan", icon: XIcon, label: "X" },
+  { href: "mailto:zhuang.eddie@gmail.com", icon: MailIcon, label: "email" },
+  { href: "https://github.com/edzhuang", icon: GitHubIcon, label: "github" },
+  {
+    href: "https://www.linkedin.com/in/eddie-zhuang",
+    icon: LinkedInIcon,
+    label: "linkedin",
+  },
+  { href: "https://x.com/edzhuan", icon: XIcon, label: "x" },
 ];
 
 export default function Home() {
@@ -34,7 +38,7 @@ export default function Home() {
       </header>
 
       <section className="mt-16">
-        <h2 className="text-sm font-medium text-muted uppercase tracking-widest">
+        <h2 className="text-sm font-medium text-muted tracking-widest">
           experience
         </h2>
         <div className="mt-6 space-y-6">
@@ -54,7 +58,7 @@ export default function Home() {
       </section>
 
       <section className="mt-16">
-        <h2 className="text-sm font-medium text-muted uppercase tracking-widest">
+        <h2 className="text-sm font-medium text-muted tracking-widest">
           projects
         </h2>
         <div className="mt-6 space-y-6">
@@ -94,26 +98,26 @@ export default function Home() {
             <a
               href={`${WEBRING_URL}#${MY_SITE}?nav=prev`}
               className="hover:text-foreground transition-colors"
-              title="Previous site"
+              title="previous site"
             >
               &larr;
             </a>
             <a
               href={WEBRING_URL}
-              title="McMaster CS & SE Webring"
+              title="mcmaster cs & se webring"
               className="leading-none"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={`${WEBRING_URL}assets/Uni_mcmaster_logo.svg.png`}
-                alt="McMaster CS & SE Webring"
+                alt="mcmaster cs & se webring"
                 className="h-5 w-auto block dark:invert"
               />
             </a>
             <a
               href={`${WEBRING_URL}#${MY_SITE}?nav=next`}
               className="hover:text-foreground transition-colors"
-              title="Next site"
+              title="next site"
             >
               &rarr;
             </a>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -2,23 +2,18 @@
 
 import { useTheme } from "next-themes";
 import { Sun, Moon } from "lucide-react";
-import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
-
-  if (!mounted) return <div className="size-5" />;
+  const { resolvedTheme, setTheme } = useTheme();
 
   return (
     <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
       className="text-foreground/60 hover:text-foreground transition-colors cursor-pointer"
-      aria-label="Toggle theme"
+      aria-label="toggle theme"
     >
-      {theme === "dark" ? <Sun className="size-5" /> : <Moon className="size-5" />}
+      <Sun className="hidden size-5 dark:block" />
+      <Moon className="block size-5 dark:hidden" />
     </button>
   );
 }


### PR DESCRIPTION
### Motivation
- Normalize label/title/alt casing across the site for consistent presentation and a11y.
- Remove client-only mount gating in the theme toggle to avoid hydration complexity and simplify theme toggling.

### Description
- Changed social link `label` values from titlecase to lowercase (e.g. `Email` → `email`, `GitHub` → `github`).
- Removed the `uppercase` class from the `experience` and `projects` headings to keep consistent text styling.
- Lowercased `title` attributes and the `alt` attribute for the webring links and image.
- Refactored `ThemeToggle` to use `resolvedTheme` from `next-themes`, removed the `mounted` state and `useEffect`, and simplified icon rendering to toggle visibility via `dark:block`/`dark:hidden` classes while updating the `onClick` toggle to use `resolvedTheme`.
- Removed an unused import in `theme-toggle.tsx` and adjusted `aria-label` casing for the toggle button.

### Testing
- Performed a type check and `next build` which completed successfully with no build errors.
- Ran `npm run lint` (ESLint) which reported no new issues.
- No automated unit tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde25d27f8832ba19d23ac4b8ce7ef)