### PR TITLE
Make webring logo render in black and white

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -111,7 +111,7 @@ export default function Home() {
               <img
                 src={`${WEBRING_URL}assets/Uni_mcmaster_logo.svg.png`}
                 alt="mcmaster cs & se webring"
-                className="h-5 w-auto block dark:invert"
+                className="h-5 w-auto block grayscale dark:invert"
               />
             </a>
             <a


### PR DESCRIPTION
### Motivation
- Ensure the webring logo appears black-and-white to match the site's monochrome aesthetic while retaining readable contrast in dark mode.

### Description
- Add the `grayscale` utility to the image `className` in `app/page.tsx`, preserving the existing `dark:invert` behavior.

### Testing
- Ran `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde63c2360832b8d6a34d380e4093b)