### PR TITLE
Fix social mail icon sizing

### DIFF
--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -23,10 +23,14 @@ function Icon({
 
 export function MailIcon({ className }: { className?: string }) {
   return (
-    <Icon
+    <svg
+      viewBox="1.5 3.75 21 16.5"
+      fill="currentColor"
       className={className}
-      path="M1.5 8.67v8.58a3 3 0 0 0 3 3h15a3 3 0 0 0 3-3V8.67l-8.928 5.493a3 3 0 0 1-3.144 0L1.5 8.67ZM22.5 6.908V6.75a3 3 0 0 0-3-3h-15a3 3 0 0 0-3 3v.158l9.714 5.978a1.5 1.5 0 0 0 1.572 0L22.5 6.908Z"
-    />
+      aria-hidden="true"
+    >
+      <path d="M1.5 8.67v8.58a3 3 0 0 0 3 3h15a3 3 0 0 0 3-3V8.67l-8.928 5.493a3 3 0 0 1-3.144 0L1.5 8.67ZM22.5 6.908V6.75a3 3 0 0 0-3-3h-15a3 3 0 0 0-3 3v.158l9.714 5.978a1.5 1.5 0 0 0 1.572 0L22.5 6.908Z" />
+    </svg>
   );
 }
 


### PR DESCRIPTION
### Motivation
- The mail icon rendered smaller than the other footer social icons because its SVG viewBox was larger than the tight bounds of the path, so the change aims to make the email icon appear the same perceived size as the others.

### Description
- Replace the `MailIcon` to render its own `<svg>` with a tighter viewBox (`1.5 3.75 21 16.5`) while keeping the existing path and preserving class-driven sizing via the `className` prop.

### Testing
- Ran `npm run lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde64c8a8c832bb0cb713ccc4158d3)