### PR TITLE
Link mcmaster heading text to mcmaster.ca

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,16 @@ export default function Home() {
         <div>
           <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
           <p className="mt-1 text-muted">
-            cs @ mcmaster · incoming @{" "}
+            cs @{" "}
+            <a
+              href="https://www.mcmaster.ca"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4 hover:text-foreground transition-colors"
+            >
+              mcmaster
+            </a>{" "}
+            · incoming @{" "}
             <a
               href="https://bondbl.com"
               target="_blank"


### PR DESCRIPTION
### Motivation
- Make the `mcmaster` text in the homepage intro a clickable external link to the university site and keep styling consistent with the existing `bond` link.

### Description
- Updated `app/page.tsx` to wrap `mcmaster` in an anchor to `https://www.mcmaster.ca` with `target="_blank"`, `rel="noopener noreferrer"`, and the same underline/hover classes as the `bond` link.

### Testing
- Ran `npm run lint` in the project root and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde675f2ac832ba12df84171cdd022)