### PR TITLE
Prioritize company names in experience section with external links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
                   >
                     {exp.company}
                   </a>{" "}
-                  <span className="text-muted font-normal">· {exp.title}</span>
+                  <span className="text-muted font-normal">{exp.title}</span>
                 </p>
                 <span className="text-sm text-muted shrink-0">{exp.date}</span>
               </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,11 +43,18 @@ export default function Home() {
         </h2>
         <div className="mt-6 space-y-6">
           {experiences.map((exp) => (
-            <div key={exp.title}>
+            <div key={`${exp.company}-${exp.title}`}>
               <div className="flex items-baseline justify-between gap-4">
                 <p className="font-medium">
-                  {exp.title}{" "}
-                  <span className="text-muted font-normal">@ {exp.company}</span>
+                  <a
+                    href={exp.companyHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-foreground underline underline-offset-4 hover:text-muted transition-colors"
+                  >
+                    {exp.company}
+                  </a>{" "}
+                  <span className="text-muted font-normal">· {exp.title}</span>
                 </p>
                 <span className="text-sm text-muted shrink-0">{exp.date}</span>
               </div>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -2,6 +2,7 @@ export const experiences = [
   {
     title: "research assistant",
     company: "mcmaster university",
+    companyHref: "https://mcmaster.ca",
     date: "2024",
     description:
       "implemented genetic algorithm techniques for reinforcement learning tasks",
@@ -9,6 +10,7 @@ export const experiences = [
   {
     title: "technology executive",
     company: "yrhacks",
+    companyHref: "https://yrhacks.ca",
     date: "2022 – 2023",
     description:
       "developed a discord bot and assisted with the website for york region's student hackathon",


### PR DESCRIPTION
### Motivation
- Make the experience entries present the company first (visually higher priority) followed by the role, matching typical résumé/site conventions.
- Turn company names into external links so visitors can navigate to the organization (e.g., `mcmaster.ca`, `yrhacks.ca`).
- Keep the role secondary in muted color and preserve existing accessible link behavior.

### Description
- Added a `companyHref` field to each experience object in `lib/data.ts` and set the provided links for the two experiences.
- Updated `app/page.tsx` to render each experience as a linked company followed by a separator dot and the job title, using `className="text-foreground"` for company and `text-muted` for the title.
- Changed the experience `key` to a composite `
`${exp.company}-${exp.title}`
` to avoid potential duplicate-key collisions.

### Testing
- Ran `npm run lint` and the linter completed successfully with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde9268330832bb26c4d0f610b629c)