### PR TITLE
Split subtitle into two lines

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,11 +20,11 @@ export const metadata: Metadata = {
   icons: {
     icon: "/icon.svg",
   },
-  description: "cs @ mcmaster · incoming @ bond",
+  description: "cs @ mcmaster, incoming @ bond",
   metadataBase: new URL("https://eddiezhuang.com"),
   openGraph: {
     title: "eddie zhuang",
-    description: "cs @ mcmaster · incoming @ bond",
+    description: "cs @ mcmaster, incoming @ bond",
     url: "https://eddiezhuang.com",
   },
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,8 +31,10 @@ export default function Home() {
               className="underline underline-offset-4 hover:text-foreground transition-colors"
             >
               mcmaster
-            </a>{" "}
-            · incoming @{" "}
+            </a>
+          </p>
+          <p className="text-muted">
+            incoming @{" "}
             <a
               href="https://bondbl.com"
               target="_blank"


### PR DESCRIPTION
## Summary
- Replace the dot separator (`·`) between "cs @ mcmaster" and "incoming @ bond" with a line break for cleaner visual hierarchy
- Update meta descriptions to use a comma separator instead

## Test plan
- [ ] Verify subtitle renders on two separate lines in the header
- [ ] Check OpenGraph/meta description reads naturally with comma

🤖 Generated with [Claude Code](https://claude.com/claude-code)