### PR TITLE
Adjust mail icon size to match social icons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,12 @@ const WEBRING_URL = "https://mac-csse-webring.vercel.app/";
 const MY_SITE = "eddiezhuang.com";
 
 const socialLinks = [
-  { href: "mailto:zhuang.eddie@gmail.com", icon: MailIcon, label: "email" },
+  {
+    href: "mailto:zhuang.eddie@gmail.com",
+    icon: MailIcon,
+    label: "email",
+    iconClassName: "size-5",
+  },
   { href: "https://github.com/edzhuang", icon: GitHubIcon, label: "github" },
   {
     href: "https://www.linkedin.com/in/eddie-zhuang",
@@ -99,7 +104,7 @@ export default function Home() {
       <footer className="mt-24 border-t border-foreground/10 pt-6 pb-8">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            {socialLinks.map(({ href, icon: Icon, label }) => (
+            {socialLinks.map(({ href, icon: Icon, label, iconClassName }) => (
               <a
                 key={label}
                 href={href}
@@ -108,7 +113,7 @@ export default function Home() {
                 className="text-muted hover:text-foreground transition-colors"
                 aria-label={label}
               >
-                <Icon className="size-4" />
+                <Icon className={iconClassName ?? "size-4"} />
               </a>
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- The mail icon in the footer rendered at a different height than the other social icons, creating an inconsistent visual appearance.

### Description
- Add an optional per-link `iconClassName` to the `socialLinks` entries and set the mail link's `iconClassName` to `"size-5"` to increase its rendered size.
- Update the footer render loop to use `iconClassName ?? "size-4"` when rendering each icon so other icons keep the default size.
- Changes made in `app/page.tsx`.

### Testing
- Ran `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce79626654832b98f36f7fc5911874)