### PR TITLE
Improve mobile spacing between experience titles and dates

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
         <div className="mt-6 space-y-6">
           {experiences.map((exp) => (
             <div key={`${exp.company}-${exp.title}`}>
-              <div className="flex items-baseline justify-between gap-4">
+              <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
                 <p className="font-medium">
                   <a
                     href={exp.companyHref}
@@ -67,7 +67,7 @@ export default function Home() {
                   </a>{" "}
                   <span className="text-muted font-normal">{exp.title}</span>
                 </p>
-                <span className="text-sm text-muted shrink-0">{exp.date}</span>
+                <span className="text-sm text-muted sm:shrink-0">{exp.date}</span>
               </div>
               <p className="mt-1 text-sm text-muted">{exp.description}</p>
             </div>


### PR DESCRIPTION
### Motivation
- Position titles and dates were too close on small screens; stacking the title/company and date on narrow viewports prevents them from running together.

### Description
- Modify `app/page.tsx` to make the experience row responsive by replacing the single-row layout with `flex flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4` and change the date element to use `sm:shrink-0` so the date only preserves non-shrinking behavior at `sm` and above.

### Testing
- Ran `npm run lint` and the linter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce797f4e70832b8b536149f8920f8d)