### PR TITLE
Fix hydration mismatch in theme toggle

### DIFF
--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,10 +1,27 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon } from "lucide-react";
 
+const emptySubscribe = () => () => {};
+
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
+  const isMounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+
+  if (!isMounted) {
+    return (
+      <button
+        className="text-foreground/60 transition-colors"
+        aria-label="toggle theme"
+        disabled
+      >
+        <Sun className="size-5" />
+      </button>
+    );
+  }
+
   const isDarkMode = resolvedTheme === "dark";
 
   return (


### PR DESCRIPTION
### Motivation
- Prevent a React hydration mismatch caused by `ThemeToggle` reading client-only theme state (`resolvedTheme`) during SSR/initial hydration so server HTML matches the first client render.

### Description
- Replace the previous mount-check with a deterministic pre-mount fallback in `components/theme-toggle.tsx` by using `useSyncExternalStore` and rendering a stable, disabled fallback button until the client is mounted, then render the theme-aware interactive button using `useTheme`.

### Testing
- Ran `npm run lint` which succeeds; `npm run build` currently fails in this environment due to external Google Fonts/Turbopack fetch errors from `fonts.gstatic.com`, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce847431a0832b86757f48416a59de)