### PR TITLE
Add social preview image

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,46 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "eddie zhuang";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  const geist = await fetch(
+    new URL(
+      "https://cdn.jsdelivr.net/fontsource/fonts/geist-sans@latest/latin-500-normal.woff"
+    )
+  ).then((res) => res.arrayBuffer());
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          color: "#ededed",
+          fontSize: 80,
+          fontFamily: "Geist",
+          fontWeight: 500,
+          letterSpacing: "-0.025em",
+        }}
+      >
+        eddie zhuang
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: "Geist",
+          data: geist,
+          style: "normal",
+          weight: 500,
+        },
+      ],
+    }
+  );
+}

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from "./opengraph-image";


### PR DESCRIPTION
## Summary
- Adds dynamically generated OG and Twitter card images using Next.js `opengraph-image.tsx` convention
- Renders "eddie zhuang" centered on the site's dark background (`#0a0a0a`) in Geist font, matching the site's styling
- Next.js automatically injects `og:image` and `twitter:image` meta tags — no changes to `layout.tsx` needed

## Test plan
- [ ] Visit `/opengraph-image` to see the generated 1200×630 PNG
- [ ] Check page source for `og:image` and `twitter:image` meta tags
- [ ] Test with a social preview validator (e.g. opengraph.xyz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)