### PR TITLE
Animate link underlines on hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -40,3 +40,16 @@ body {
 .animate-fade-in {
   animation: fade-in 0.6s ease-out both;
 }
+
+.animated-underline {
+  background-image: linear-gradient(currentColor, currentColor);
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  background-size: 0% 1px;
+  transition: background-size 0.3s ease-out, color 0.2s ease-out;
+  padding-bottom: 2px;
+}
+
+.animated-underline:hover {
+  background-size: 100% 1px;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function Home() {
               href="https://www.mcmaster.ca"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline underline-offset-4 hover:text-foreground transition-colors"
+              className="animated-underline text-foreground"
             >
               mcmaster
             </a>
@@ -46,7 +46,7 @@ export default function Home() {
               href="https://bondbl.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline underline-offset-4 hover:text-foreground transition-colors"
+              className="animated-underline text-foreground"
             >
               bond
             </a>
@@ -67,7 +67,7 @@ export default function Home() {
                     href={exp.companyHref}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-foreground underline underline-offset-4 hover:text-muted transition-colors"
+                    className="animated-underline text-foreground hover:text-muted"
                   >
                     {exp.company}
                   </a>{" "}
@@ -92,7 +92,7 @@ export default function Home() {
                 href={project.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-medium underline underline-offset-4 hover:text-muted transition-colors"
+                className="animated-underline font-medium hover:text-muted"
               >
                 {project.name}
               </a>


### PR DESCRIPTION
## Summary
- Added an `.animated-underline` utility that hides the underline by default and slides it in left-to-right on hover via a `background-size` transition.
- Swapped all four inline text links (mcmaster, bond, company name in experience, project name) over to the new utility.
- Bumped the inline `mcmaster` / `bond` links to `text-foreground` so they stay discoverable against the muted surrounding copy — matching the existing pattern in the experience section.

## Test plan
- [x] Verified in browser preview: links appear without underline, underline slides in on hover.
- [x] `mcmaster` and `bond` are visually distinguishable from the surrounding `text-muted` copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)