### PR TITLE
Fix fade-in on client navigation and add staggered top-to-bottom animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,8 +37,34 @@ body {
   }
 }
 
-.animate-fade-in {
-  animation: fade-in 0.6s ease-out both;
+.staggered-fade-in > * {
+  opacity: 0;
+  animation: fade-in 0.55s ease-out both;
+  animation-delay: calc(var(--stagger-index, 0) * 110ms);
+}
+
+.staggered-fade-in > :nth-child(1) {
+  --stagger-index: 0;
+}
+
+.staggered-fade-in > :nth-child(2) {
+  --stagger-index: 1;
+}
+
+.staggered-fade-in > :nth-child(3) {
+  --stagger-index: 2;
+}
+
+.staggered-fade-in > :nth-child(4) {
+  --stagger-index: 3;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .staggered-fade-in > * {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .animated-underline {
@@ -46,7 +72,9 @@ body {
   background-position: 0 100%;
   background-repeat: no-repeat;
   background-size: 0% 1px;
-  transition: background-size 0.3s ease-out, color 0.2s ease-out;
+  transition:
+    background-size 0.3s ease-out,
+    color 0.2s ease-out;
   padding-bottom: 2px;
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { ThemeToggle } from "@/components/theme-toggle";
 import { experiences, projects } from "@/lib/data";
 import { MailIcon, GitHubIcon, LinkedInIcon, XIcon } from "@/components/icons";
+import { RouteTransition } from "@/components/route-transition";
 
 const WEBRING_URL = "https://mac-csse-webring.vercel.app/";
 const MY_SITE = "eddiezhuang.com";
@@ -22,132 +23,132 @@ const socialLinks = [
 
 export default function Home() {
   return (
-    <main className="mx-auto w-full max-w-2xl px-6 py-16 md:py-24 animate-fade-in">
-      <header>
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
-          <ThemeToggle />
-        </div>
-        <div>
-          <p className="mt-1 text-muted">
-            cs @{" "}
-            <a
-              href="https://www.mcmaster.ca"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="animated-underline text-foreground hover:text-muted"
-            >
-              mcmaster
-            </a>
-          </p>
-          <p className="text-muted">
-            incoming @{" "}
-            <a
-              href="https://bondbl.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="animated-underline text-foreground hover:text-muted"
-            >
-              bond
-            </a>
-          </p>
-        </div>
-      </header>
+    <main className="mx-auto w-full max-w-2xl px-6 py-16 md:py-24">
+      <RouteTransition className="staggered-fade-in">
+        <header>
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-medium tracking-tight">
+              eddie zhuang
+            </h1>
+            <ThemeToggle />
+          </div>
+          <div>
+            <p className="mt-1 text-muted">
+              cs @{" "}
+              <a
+                href="https://www.mcmaster.ca"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="animated-underline text-foreground hover:text-muted"
+              >
+                mcmaster
+              </a>
+            </p>
+            <p className="text-muted">
+              incoming @{" "}
+              <a
+                href="https://bondbl.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="animated-underline text-foreground hover:text-muted"
+              >
+                bond
+              </a>
+            </p>
+          </div>
+        </header>
 
-      <section className="mt-16">
-        <h2 className="text-base text-muted">
-          experience
-        </h2>
-        <div className="mt-6 space-y-6">
-          {experiences.map((exp) => (
-            <div key={`${exp.company}-${exp.title}`}>
-              <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
-                <p className="font-medium">
-                  <a
-                    href={exp.companyHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="animated-underline text-foreground hover:text-muted"
-                  >
-                    {exp.company}
-                  </a>{" "}
-                  <span className="text-muted font-normal">{exp.title}</span>
-                </p>
-                <span className="text-muted sm:shrink-0">{exp.date}</span>
+        <section className="mt-16">
+          <h2 className="text-base text-muted">experience</h2>
+          <div className="mt-6 space-y-6">
+            {experiences.map((exp) => (
+              <div key={`${exp.company}-${exp.title}`}>
+                <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+                  <p className="font-medium">
+                    <a
+                      href={exp.companyHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="animated-underline text-foreground hover:text-muted"
+                    >
+                      {exp.company}
+                    </a>{" "}
+                    <span className="text-muted font-normal">{exp.title}</span>
+                  </p>
+                  <span className="text-muted sm:shrink-0">{exp.date}</span>
+                </div>
+                <p className="mt-1 text-sm text-muted">{exp.description}</p>
               </div>
-              <p className="mt-1 text-sm text-muted">{exp.description}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="mt-16">
-        <h2 className="text-base text-muted">
-          projects
-        </h2>
-        <div className="mt-6 space-y-6">
-          {projects.map((project) => (
-            <div key={project.name}>
-              <a
-                href={project.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="animated-underline font-medium hover:text-muted"
-              >
-                {project.name}
-              </a>
-              <p className="mt-1 text-sm text-muted">{project.description}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <footer className="mt-24 border-t border-foreground/10 pt-6 pb-8">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            {socialLinks.map(({ href, icon: Icon, label }) => (
-              <a
-                key={label}
-                href={href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-muted hover:text-foreground transition-colors"
-                aria-label={label}
-              >
-                <Icon size={20} />
-              </a>
             ))}
           </div>
-          <div className="flex items-center gap-2 text-sm text-muted">
-            <a
-              href={`${WEBRING_URL}#${MY_SITE}?nav=prev`}
-              className="hover:text-foreground transition-colors"
-              title="previous site"
-            >
-              &larr;
-            </a>
-            <a
-              href={WEBRING_URL}
-              title="mcmaster cs & se webring"
-              className="leading-none"
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={`${WEBRING_URL}assets/Uni_mcmaster_logo.svg.png`}
-                alt="mcmaster cs & se webring"
-                className="h-5 w-auto block grayscale dark:invert"
-              />
-            </a>
-            <a
-              href={`${WEBRING_URL}#${MY_SITE}?nav=next`}
-              className="hover:text-foreground transition-colors"
-              title="next site"
-            >
-              &rarr;
-            </a>
+        </section>
+
+        <section className="mt-16">
+          <h2 className="text-base text-muted">projects</h2>
+          <div className="mt-6 space-y-6">
+            {projects.map((project) => (
+              <div key={project.name}>
+                <a
+                  href={project.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="animated-underline font-medium hover:text-muted"
+                >
+                  {project.name}
+                </a>
+                <p className="mt-1 text-sm text-muted">{project.description}</p>
+              </div>
+            ))}
           </div>
-        </div>
-      </footer>
+        </section>
+
+        <footer className="mt-24 border-t border-foreground/10 pt-6 pb-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              {socialLinks.map(({ href, icon: Icon, label }) => (
+                <a
+                  key={label}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted hover:text-foreground transition-colors"
+                  aria-label={label}
+                >
+                  <Icon size={20} />
+                </a>
+              ))}
+            </div>
+            <div className="flex items-center gap-2 text-sm text-muted">
+              <a
+                href={`${WEBRING_URL}#${MY_SITE}?nav=prev`}
+                className="hover:text-foreground transition-colors"
+                title="previous site"
+              >
+                &larr;
+              </a>
+              <a
+                href={WEBRING_URL}
+                title="mcmaster cs & se webring"
+                className="leading-none"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={`${WEBRING_URL}assets/Uni_mcmaster_logo.svg.png`}
+                  alt="mcmaster cs & se webring"
+                  className="h-5 w-auto block grayscale dark:invert"
+                />
+              </a>
+              <a
+                href={`${WEBRING_URL}#${MY_SITE}?nav=next`}
+                className="hover:text-foreground transition-colors"
+                title="next site"
+              >
+                &rarr;
+              </a>
+            </div>
+          </div>
+        </footer>
+      </RouteTransition>
     </main>
   );
 }

--- a/components/route-transition.tsx
+++ b/components/route-transition.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+type RouteTransitionProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function RouteTransition({ children, className }: RouteTransitionProps) {
+  const pathname = usePathname();
+
+  return (
+    <div key={pathname} className={className}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Ensure the page entry animation reliably plays on client-side navigation (not only on full reload) in Chrome and other browsers.  
- Provide a tiered reveal so content appears from top to bottom (header → experience → projects → footer).  
- Respect user accessibility preferences by disabling animations for `prefers-reduced-motion` users.

### Description
- Add a small client component `RouteTransition` that keys its wrapper by `pathname` to force remounting on navigation and retrigger entry animations (`components/route-transition.tsx`).
- Wrap the home page content in `RouteTransition` and apply the new stagger class to the top-level container (`app/page.tsx`).
- Replace the single-container `fade-in` usage with a staged CSS approach in `app/globals.css` that applies `fade-in` to each immediate child and staggers start times using `:nth-child()` and a `--stagger-index` variable.  
- Add a `@media (prefers-reduced-motion: reduce)` rule to disable animations and ensure elements remain visible for reduced-motion users.

### Testing
- Ran `pnpm exec prettier --write app/page.tsx components/route-transition.tsx app/globals.css` and formatting completed successfully.  
- Ran the project linter via `pnpm lint` (which runs `eslint`) and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29e301b7c832bb6a38a860b06c580)