### PR TITLE
Stagger fade-in on mount to fix background-tab bug

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { FadeIn } from "@/components/fade-in";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { experiences, projects } from "@/lib/data";
 import { MailIcon, GitHubIcon, LinkedInIcon, XIcon } from "@/components/icons";
@@ -22,8 +23,8 @@ const socialLinks = [
 
 export default function Home() {
   return (
-    <main className="mx-auto w-full max-w-2xl px-6 py-16 md:py-24 animate-fade-in">
-      <header>
+    <main className="mx-auto w-full max-w-2xl px-6 py-16 md:py-24">
+      <FadeIn as="header" delay={0}>
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
           <ThemeToggle />
@@ -52,9 +53,9 @@ export default function Home() {
             </a>
           </p>
         </div>
-      </header>
+      </FadeIn>
 
-      <section className="mt-16">
+      <FadeIn as="section" delay={150} className="mt-16">
         <h2 className="text-base text-muted">
           experience
         </h2>
@@ -79,9 +80,9 @@ export default function Home() {
             </div>
           ))}
         </div>
-      </section>
+      </FadeIn>
 
-      <section className="mt-16">
+      <FadeIn as="section" delay={300} className="mt-16">
         <h2 className="text-base text-muted">
           projects
         </h2>
@@ -100,9 +101,13 @@ export default function Home() {
             </div>
           ))}
         </div>
-      </section>
+      </FadeIn>
 
-      <footer className="mt-24 border-t border-foreground/10 pt-6 pb-8">
+      <FadeIn
+        as="footer"
+        delay={450}
+        className="mt-24 border-t border-foreground/10 pt-6 pb-8"
+      >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             {socialLinks.map(({ href, icon: Icon, label }) => (
@@ -147,7 +152,7 @@ export default function Home() {
             </a>
           </div>
         </div>
-      </footer>
+      </FadeIn>
     </main>
   );
 }

--- a/components/fade-in.tsx
+++ b/components/fade-in.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import {
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ElementType,
+  type ReactNode,
+} from "react";
+
+type FadeInProps = {
+  as?: ElementType;
+  delay?: number;
+  className?: string;
+  children: ReactNode;
+};
+
+export function FadeIn({
+  as: Tag = "div",
+  delay = 0,
+  className = "",
+  children,
+}: FadeInProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const style: CSSProperties | undefined = mounted
+    ? { animationDelay: `${delay}ms` }
+    : undefined;
+  const animClass = mounted ? "animate-fade-in" : "opacity-0";
+
+  return (
+    <Tag className={`${className} ${animClass}`.trim()} style={style}>
+      {children}
+    </Tag>
+  );
+}


### PR DESCRIPTION
## Summary
- The fade-in was a pure CSS animation applied to `<main>` in server-rendered HTML. CSS animation clocks tick while a tab is in the background, so opening many tabs via cmd+click caused the fade-in to appear progressively shorter (or not at all) — by the time the user viewed a background tab, part or all of the 0.6s animation had already elapsed.
- Added a small `<FadeIn>` client component that applies `opacity-0` during SSR/pre-mount and swaps to `animate-fade-in` after `useEffect` runs, so the animation clock only starts once the tab is being viewed.
- Wrapped `<header>`, both `<section>`s, and `<footer>` with staggered delays (0 / 150 / 300 / 450 ms) so sections fade in top-to-bottom.
- `app/page.tsx` stays a server component — only the wrapper carries `"use client"`, keeping the data arrays and icon imports server-only.

## Test plan
- [x] Reloaded the page in the preview — console clean, all four sections render at opacity: 1 with `animationDelay` 0s / 0.15s / 0.3s / 0.45s.
- [x] Verified the SSR HTML ships `opacity-0` on each tier (so there's no flash of fully-rendered content before hydration).
- [ ] Manually verify: cmd+click to open several tabs of the deployed site and confirm each tab plays the full staggered fade-in when focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)