### PR TITLE
Add blur transition to fade-in animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -30,10 +30,12 @@ body {
   from {
     opacity: 0;
     transform: translateY(8px);
+    filter: blur(8px);
   }
   to {
     opacity: 1;
     transform: translateY(0);
+    filter: blur(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- Extends the `fade-in` keyframes in `app/globals.css` to animate `filter` from `blur(8px)` to `blur(0)` alongside the existing opacity and translate transitions, giving content a softer entrance as it mounts.

## Test plan
- [ ] Load the site and confirm the homepage content un-blurs as it fades in
- [ ] Navigate between pages and verify staggered fade-in still works with the new blur
- [ ] Check that no layout shift or performance regressions appear on lower-powered devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)