### PR TITLE
Fix fade-in starting mid-animation on reload

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -39,8 +39,21 @@ body {
   }
 }
 
+.fade-in-initial {
+  opacity: 0;
+}
+
 .animate-fade-in {
   animation: fade-in 0.6s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in-initial {
+    opacity: 1;
+  }
+  .animate-fade-in {
+    animation: none;
+  }
 }
 
 .animated-underline {

--- a/components/fade-in.tsx
+++ b/components/fade-in.tsx
@@ -2,8 +2,7 @@
 
 import {
   useEffect,
-  useState,
-  type CSSProperties,
+  useRef,
   type ElementType,
   type ReactNode,
 } from "react";
@@ -21,19 +20,21 @@ export function FadeIn({
   className = "",
   children,
 }: FadeInProps) {
-  const [mounted, setMounted] = useState(false);
+  const ref = useRef<HTMLElement>(null);
 
   useEffect(() => {
-    setMounted(true);
-  }, []);
+    const el = ref.current;
+    if (!el) return;
 
-  const style: CSSProperties | undefined = mounted
-    ? { animationDelay: `${delay}ms` }
-    : undefined;
-  const animClass = mounted ? "animate-fade-in" : "opacity-0";
+    const raf = requestAnimationFrame(() => {
+      el.style.animationDelay = `${delay}ms`;
+      el.classList.add("animate-fade-in");
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [delay]);
 
   return (
-    <Tag className={`${className} ${animClass}`.trim()} style={style}>
+    <Tag ref={ref} className={`fade-in-initial ${className}`.trim()}>
       {children}
     </Tag>
   );


### PR DESCRIPTION
## Summary

- On reload the fade-in sometimes visibly started partway through, with most elements already visible.
- Root cause: the `useState`/`useEffect` mount flag in `FadeIn` forced a second React render after hydration to swap `opacity-0` → `animate-fade-in`. The class swap committed outside the browser's paint frame, so by the time the new style resolved, the CSS animation clock had already advanced past the first paintable frame.
- Fix: apply `animate-fade-in` directly via a ref inside `requestAnimationFrame`, which aligns the animation start with a paint tick and skips the extra render. `rAF` is still throttled in background tabs, so the cmd+click fix from #21 is preserved.
- Also added `prefers-reduced-motion` support, which the previous implementation was missing.

## Test plan

- [x] Reload `/` — each section starts at opacity 0 and fades in cleanly with the staggered 0/150/300/450ms delays (verified by sampling `getComputedStyle(...).opacity` at 50ms intervals).
- [ ] Cmd+click the site into a background tab, wait, switch to it — animation plays from the start rather than being half-over.
- [ ] Toggle OS "Reduce motion" — elements appear immediately at full opacity with no animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)