### PR TITLE
Switch fade-in to Web Animations API

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,33 +26,13 @@ body {
   font-family: var(--font-sans), system-ui, sans-serif;
 }
 
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-    filter: blur(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-    filter: blur(0);
-  }
-}
-
 .fade-in-initial {
   opacity: 0;
-}
-
-.animate-fade-in {
-  animation: fade-in 0.6s ease-out both;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .fade-in-initial {
     opacity: 1;
-  }
-  .animate-fade-in {
-    animation: none;
   }
 }
 

--- a/components/fade-in.tsx
+++ b/components/fade-in.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useEffect,
-  useRef,
-  type ElementType,
-  type ReactNode,
-} from "react";
+import { useEffect, useRef, type ElementType, type ReactNode } from "react";
 
 type FadeInProps = {
   as?: ElementType;
@@ -26,11 +21,30 @@ export function FadeIn({
     const el = ref.current;
     if (!el) return;
 
-    const raf = requestAnimationFrame(() => {
-      el.style.animationDelay = `${delay}ms`;
-      el.classList.add("animate-fade-in");
-    });
-    return () => cancelAnimationFrame(raf);
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      el.style.opacity = "1";
+      el.style.filter = "none";
+      el.style.transform = "none";
+      return;
+    }
+
+    const animation = el.animate(
+      [
+        { opacity: 0, transform: "translateY(8px)", filter: "blur(8px)" },
+        { opacity: 1, transform: "translateY(0)", filter: "blur(0)" },
+      ],
+      {
+        duration: 600,
+        delay,
+        easing: "ease-out",
+        fill: "both",
+      },
+    );
+
+    return () => animation.cancel();
   }, [delay]);
 
   return (


### PR DESCRIPTION
## Summary

Follow-up to #24. The rAF+classList approach still left the CSS animation's clock subject to drift against React's commit timing in production builds, so on reload the animation still sometimes appeared to start partway through.

Replace with `element.animate()` (Web Animations API):
- `startTime` is bound to the moment `animate()` is called — verified: it tracks `document.timeline.currentTime` at call time, not navigation origin, so hydration latency no longer eats animation frames.
- WAAPI runs on the compositor thread, independent of main-thread hydration work, so the animation stays smooth even while React is busy.
- Keyframes live inline in JS; dropped the now-unused `@keyframes fade-in` and `.animate-fade-in` CSS.
- Preserved the `prefers-reduced-motion` short-circuit.

## Test plan

- [x] Reload `/` — each section runs its WAAPI animation (600ms, `finished` state) and ends at opacity 1, blur 0, no transform.
- [ ] Production deploy — confirm the "starts halfway through" regression is gone.
- [ ] Cmd+click into a background tab, switch back — animation plays from start (WAAPI pauses with the document timeline when the tab is hidden).
- [ ] Toggle OS "Reduce motion" — elements appear immediately at full opacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)