### PR TITLE
Add Bond experience entry and lengthen fade-in stagger

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,33 +29,10 @@ export default function Home() {
           <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
           <ThemeToggle />
         </div>
-        <div>
-          <p className="mt-1 text-muted">
-            cs @{" "}
-            <a
-              href="https://www.mcmaster.ca"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="animated-underline text-foreground hover:text-muted"
-            >
-              mcmaster
-            </a>
-          </p>
-          <p className="text-muted">
-            incoming @{" "}
-            <a
-              href="https://bondbl.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="animated-underline text-foreground hover:text-muted"
-            >
-              bond
-            </a>
-          </p>
-        </div>
+        <p className="mt-1 text-muted">cs @ mcmaster</p>
       </FadeIn>
 
-      <FadeIn as="section" delay={150} className="mt-16">
+      <FadeIn as="section" delay={250} className="mt-16">
         <h2 className="text-base text-muted">
           experience
         </h2>
@@ -82,7 +59,7 @@ export default function Home() {
         </div>
       </FadeIn>
 
-      <FadeIn as="section" delay={300} className="mt-16">
+      <FadeIn as="section" delay={500} className="mt-16">
         <h2 className="text-base text-muted">
           projects
         </h2>
@@ -105,7 +82,7 @@ export default function Home() {
 
       <FadeIn
         as="footer"
-        delay={450}
+        delay={750}
         className="mt-24 border-t border-foreground/10 pt-6 pb-8"
       >
         <div className="flex items-center justify-between">

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,5 +1,13 @@
 export const experiences = [
   {
+    title: "ai solutions developer intern",
+    company: "bond brand loyalty",
+    companyHref: "https://bondbl.com",
+    date: "summer 2026 (incoming)",
+    description:
+      "developing ai tools and applications for loyalty marketing clients",
+  },
+  {
     title: "research assistant",
     company: "mcmaster university",
     companyHref: "https://mcmaster.ca",


### PR DESCRIPTION
## Summary
- Add incoming Bond Brand Loyalty AI solutions developer intern role to the top of the experience section
- Drop the redundant "incoming @ bond" header line and remove the link from "cs @ mcmaster" so the header stays minimal
- Bump section fade-in delays from 0/150/300/450ms to 0/250/500/750ms for a more noticeable staggered entrance

## Test plan
- [x] Verified in dev server: Bond entry sits above McMaster with matching lowercase/terse formatting
- [x] Verified header shows only "cs @ mcmaster" (unlinked)
- [x] Verified transition-delay values on each FadeIn wrapper: 0/250/500/750ms
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)