### PR TITLE
Distinguish experience dates from titles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
                   </a>{" "}
                   <span className="text-muted font-normal">{exp.title}</span>
                 </p>
-                <span className="text-muted sm:shrink-0">{exp.date}</span>
+                <span className="text-sm text-muted tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
               <p className="mt-1 text-sm text-muted">{exp.description}</p>
             </div>


### PR DESCRIPTION
## Summary
- Drop the experience-row date to `text-sm` with `tabular-nums` so it reads as metadata instead of competing with the position title
- Dates now align vertically across rows thanks to tabular figures

## Test plan
- [ ] Visit `/` and confirm the date column reads quieter than the company/title line
- [ ] Verify dates align vertically across experience rows
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)