### PR TITLE
Adjust experience date typography

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
                   </a>{" "}
                   <span className="text-muted font-normal">{exp.title}</span>
                 </p>
-                <span className="text-foreground/50 tabular-nums sm:shrink-0">{exp.date}</span>
+                <span className="text-foreground/35 tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
               <p className="mt-1 text-sm text-muted">{exp.description}</p>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
                   </a>{" "}
                   <span className="text-muted font-normal">{exp.title}</span>
                 </p>
-                <span className="text-sm text-muted tabular-nums sm:shrink-0">{exp.date}</span>
+                <span className="text-foreground/50 tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
               <p className="mt-1 text-sm text-muted">{exp.description}</p>
             </div>


### PR DESCRIPTION
### Motivation
- Make the experience date text the same size as the company/job line while keeping it visually de-emphasized.

### Description
- Updated `app/page.tsx` to remove the `text-sm` class from the experience date span and apply `text-foreground/50` so the date matches the company/job size but appears dimmer.

### Testing
- Ran `pnpm lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69fc27fb8832bacdc45222c491c27)