### PR TITLE
Use explicit foreground color utilities instead of `text-muted`

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,13 +3,13 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-  --muted: #737373;
+  --muted: #8a8a8a;
 }
 
 .dark {
   --background: #0a0a0a;
   --foreground: #ededed;
-  --muted: #a3a3a3;
+  --muted: #8a8a8a;
 }
 
 @theme inline {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
           <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
           <ThemeToggle />
         </div>
-        <p className="mt-1 text-foreground/70">cs @ mcmaster</p>
+        <p className="mt-1 text-muted">cs @ mcmaster</p>
       </FadeIn>
 
       <FadeIn as="section" delay={250} className="mt-16">
@@ -51,7 +51,7 @@ export default function Home() {
                   </a>{" "}
                   <span className="text-foreground/70 font-normal">{exp.title}</span>
                 </p>
-                <span className="text-foreground/35 tabular-nums sm:shrink-0">{exp.date}</span>
+                <span className="text-muted tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
               <p className="mt-1 text-sm text-muted">{exp.description}</p>
             </div>
@@ -70,7 +70,7 @@ export default function Home() {
                 href={project.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="animated-underline font-medium hover:text-foreground/80"
+                className="animated-underline text-foreground font-medium hover:text-foreground/80"
               >
                 {project.name}
               </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,11 +29,11 @@ export default function Home() {
           <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
           <ThemeToggle />
         </div>
-        <p className="mt-1 text-muted">cs @ mcmaster</p>
+        <p className="mt-1 text-foreground/80">cs @ mcmaster</p>
       </FadeIn>
 
       <FadeIn as="section" delay={250} className="mt-16">
-        <h2 className="text-base text-foreground/70">
+        <h2 className="text-base text-foreground/80">
           experience
         </h2>
         <div className="mt-6 space-y-6">
@@ -49,7 +49,7 @@ export default function Home() {
                   >
                     {exp.company}
                   </a>{" "}
-                  <span className="text-foreground/70 font-normal">{exp.title}</span>
+                  <span className="text-foreground/80 font-normal">{exp.title}</span>
                 </p>
                 <span className="text-muted tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
@@ -60,7 +60,7 @@ export default function Home() {
       </FadeIn>
 
       <FadeIn as="section" delay={500} className="mt-16">
-        <h2 className="text-base text-foreground/70">
+        <h2 className="text-base text-foreground/80">
           projects
         </h2>
         <div className="mt-6 space-y-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,11 +29,11 @@ export default function Home() {
           <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
           <ThemeToggle />
         </div>
-        <p className="mt-1 text-foreground/80">cs @ mcmaster</p>
+        <p className="mt-1 text-foreground/70">cs @ mcmaster</p>
       </FadeIn>
 
       <FadeIn as="section" delay={250} className="mt-16">
-        <h2 className="text-base text-foreground/80">
+        <h2 className="text-base text-foreground/70">
           experience
         </h2>
         <div className="mt-6 space-y-6">
@@ -49,7 +49,7 @@ export default function Home() {
                   >
                     {exp.company}
                   </a>{" "}
-                  <span className="text-foreground/80 font-normal">{exp.title}</span>
+                  <span className="text-foreground/70 font-normal">{exp.title}</span>
                 </p>
                 <span className="text-muted tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
@@ -60,7 +60,7 @@ export default function Home() {
       </FadeIn>
 
       <FadeIn as="section" delay={500} className="mt-16">
-        <h2 className="text-base text-foreground/80">
+        <h2 className="text-base text-foreground/70">
           projects
         </h2>
         <div className="mt-6 space-y-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,11 +29,11 @@ export default function Home() {
           <h1 className="text-2xl font-medium tracking-tight">eddie zhuang</h1>
           <ThemeToggle />
         </div>
-        <p className="mt-1 text-muted">cs @ mcmaster</p>
+        <p className="mt-1 text-foreground/70">cs @ mcmaster</p>
       </FadeIn>
 
       <FadeIn as="section" delay={250} className="mt-16">
-        <h2 className="text-base text-muted">
+        <h2 className="text-base text-foreground/70">
           experience
         </h2>
         <div className="mt-6 space-y-6">
@@ -45,11 +45,11 @@ export default function Home() {
                     href={exp.companyHref}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="animated-underline text-foreground hover:text-muted"
+                    className="animated-underline text-foreground hover:text-foreground/80"
                   >
                     {exp.company}
                   </a>{" "}
-                  <span className="text-muted font-normal">{exp.title}</span>
+                  <span className="text-foreground/70 font-normal">{exp.title}</span>
                 </p>
                 <span className="text-foreground/35 tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
@@ -60,7 +60,7 @@ export default function Home() {
       </FadeIn>
 
       <FadeIn as="section" delay={500} className="mt-16">
-        <h2 className="text-base text-muted">
+        <h2 className="text-base text-foreground/70">
           projects
         </h2>
         <div className="mt-6 space-y-6">
@@ -70,7 +70,7 @@ export default function Home() {
                 href={project.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="animated-underline font-medium hover:text-muted"
+                className="animated-underline font-medium hover:text-foreground/80"
               >
                 {project.name}
               </a>


### PR DESCRIPTION
### Motivation

- Replace the legacy `text-muted` utility with explicit `text-foreground` opacity classes to align with updated design tokens and ensure consistent theming across light/dark modes.
- Make hover states use a clearer `text-foreground` opacity for better contrast and predictability.

### Description

- Replaced `text-muted` with `text-foreground/70` for subtle text such as the header subtitle and section headings.
- Updated interactive link hover styles from `hover:text-muted` to `hover:text-foreground/80` for projects and company links.
- Adjusted company title spans to `text-foreground/70` while keeping the primary `text-foreground` for link text and other foreground tokens.

### Testing

- Ran a Next.js production build with `next build` which completed successfully.
- Performed TypeScript type checking with `tsc` which reported no errors.
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a3281884832b93575c1b0335225e)