### PR TITLE
Make muted text more muted in both light and dark modes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,13 +3,13 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-  --muted: #8a8a8a;
+  --muted: #ababab;
 }
 
 .dark {
   --background: #0a0a0a;
   --foreground: #ededed;
-  --muted: #8a8a8a;
+  --muted: #666666;
 }
 
 @theme inline {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
                   </a>{" "}
                   <span className="text-foreground/70 font-normal">{exp.title}</span>
                 </p>
-                <span className="text-muted tabular-nums sm:shrink-0">{exp.date}</span>
+                <span className="text-sm text-muted tabular-nums sm:shrink-0">{exp.date}</span>
               </div>
               <p className="mt-1 text-sm text-muted">{exp.description}</p>
             </div>


### PR DESCRIPTION
Light mode: #8a8a8a → #ababab (lower contrast against white)
Dark mode: #8a8a8a → #666666 (lower contrast against near-black)

https://claude.ai/code/session_01Qw7rLn9LrMVrqhJcVQdTUV