### PR TITLE
Fix favicon circle size and center the “e” glyph

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="e favicon">
-  <circle cx="32" cy="32" r="30" fill="#000000" />
+  <circle cx="32" cy="32" r="32" fill="#000000" />
   <text
-    x="50%"
-    y="53%"
+    x="32"
+    y="32"
     text-anchor="middle"
     dominant-baseline="middle"
     fill="#ffffff"


### PR DESCRIPTION
### Motivation
- The favicon circle appeared undersized and the letter "e" was visually off-center, so the icon should fill the canvas and the glyph must be exactly centered.

### Description
- Adjusted `app/icon.svg` by increasing the circle radius to `r="32"` for a full 64×64 canvas fill and replaced the percentage positions with explicit coordinates `x="32"` and `y="32"` to center the glyph while keeping existing anchoring and font settings.

### Testing
- Validated the SVG by parsing it with `python - <<'PY'\nimport xml.etree.ElementTree as ET\nET.parse('app/icon.svg')\nprint('ok')\nPY` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97241f7fc832b9d0560ab39f88bb8)