### PR TITLE
Fix preview rendering in forwarded dev ports

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,6 +26,31 @@ body {
   font-family: var(--font-sans), system-ui, sans-serif;
 }
 
+.fade-in {
+  animation: fade-in 900ms ease-out both;
+  animation-delay: var(--fade-in-delay, 0ms);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+    filter: blur(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    animation: none;
+  }
+}
+
 .animated-underline {
   background-image: linear-gradient(currentColor, currentColor);
   background-position: 0 100%;

--- a/components/fade-in.tsx
+++ b/components/fade-in.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { useEffect, useRef, type CSSProperties, type ElementType, type ReactNode } from "react";
+import { type CSSProperties, type ElementType, type ReactNode } from "react";
 
 type FadeInProps = {
   as?: ElementType;
@@ -9,59 +7,17 @@ type FadeInProps = {
   children: ReactNode;
 };
 
-const INITIAL_STYLE: CSSProperties = {
-  opacity: 0,
-  transform: "translateY(8px)",
-  filter: "blur(8px)",
-};
-
-const FINAL_STYLE: CSSProperties = {
-  opacity: 1,
-  transform: "translateY(0)",
-  filter: "blur(0)",
-};
-
 export function FadeIn({
   as: Tag = "div",
   delay = 0,
   className = "",
   children,
 }: FadeInProps) {
-  const ref = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      Object.assign(el.style, FINAL_STYLE);
-      return;
-    }
-
-    let raf1 = 0;
-    let raf2 = 0;
-
-    Object.assign(el.style, INITIAL_STYLE);
-    el.style.transition = "none";
-
-    raf1 = window.requestAnimationFrame(() => {
-      raf2 = window.requestAnimationFrame(() => {
-        el.style.transitionProperty = "opacity, transform, filter";
-        el.style.transitionDuration = "900ms";
-        el.style.transitionTimingFunction = "ease-out";
-        el.style.transitionDelay = `${delay}ms`;
-        Object.assign(el.style, FINAL_STYLE);
-      });
-    });
-
-    return () => {
-      window.cancelAnimationFrame(raf1);
-      window.cancelAnimationFrame(raf2);
-    };
-  }, [delay]);
-
   return (
-    <Tag ref={ref} style={INITIAL_STYLE} className={className}>
+    <Tag
+      style={{ "--fade-in-delay": `${delay}ms` } as CSSProperties}
+      className={["fade-in", className].filter(Boolean).join(" ")}
+    >
       {children}
     </Tag>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: ["127.0.0.1", "0.0.0.0", "*.localhost"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move fade-in behavior from client-side effects to CSS so page content is visible even if hydration or dev resources are delayed/blocked in previews
- Allow common local forwarded development origins in Next.js dev config

## Testing
- `pnpm lint`
- `pnpm build`
- Restarted `pnpm dev --hostname 0.0.0.0`
- Verified local page requests return 200 and a cross-origin request to a Next dev endpoint is no longer rejected with 403
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c7fbe07-97fd-4a35-98c6-0312b5a74da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c7fbe07-97fd-4a35-98c6-0312b5a74da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

