### PR TITLE
Prevent fade blur from persisting

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -35,13 +35,11 @@ body {
   from {
     opacity: 0;
     transform: translateY(8px);
-    filter: blur(8px);
   }
 
   to {
     opacity: 1;
     transform: translateY(0);
-    filter: blur(0);
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -27,7 +27,7 @@ body {
 }
 
 .fade-in {
-  animation: fade-in 900ms ease-out both;
+  animation: fade-in 900ms ease-out backwards;
   animation-delay: var(--fade-in-delay, 0ms);
 }
 
@@ -35,11 +35,13 @@ body {
   from {
     opacity: 0;
     transform: translateY(8px);
+    filter: blur(8px);
   }
 
   to {
     opacity: 1;
     transform: translateY(0);
+    filter: blur(0);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restore the blur-to-sharp fade-in effect
- Use `animation-fill-mode: backwards` so the blur filter is only applied before/during the animation and is not retained after completion

## Testing
- `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c7fbe07-97fd-4a35-98c6-0312b5a74da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c7fbe07-97fd-4a35-98c6-0312b5a74da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

